### PR TITLE
replace lodash.* dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "lodash.camelcase": "^4.3.0",
     "lodash.isequalwith": "^4.4.0",
     "lodash.shuffle": "^4.2.0",
+    "lodash.omit": "^4.5.0",
     "mocha": "^3.2.0",
     "node-notifier": "^4.6.1",
     "rc-slider": "^5.4.3",
@@ -62,11 +63,10 @@
     "webpack": "^1.14.0"
   },
   "dependencies": {
+    "debounce": "^1.0.0",
     "enquire.js": "^2.1.1",
     "imagesloaded": "^4.1.1",
-    "lodash.debounce": "^4.0.8",
-    "lodash.omit": "^4.5.0",
-    "lodash.partition": "^4.6.0",
+    "just-omit": "^1.0.1",
     "react-addons-transition-group": "^15.4.2",
     "react-motion": "^0.4.7",
     "shallowequal": "^0.2.2"

--- a/src/components/CSSGrid.jsx
+++ b/src/components/CSSGrid.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import ReactTransitionGroup from 'react-addons-transition-group';
 import shallowEqual from 'shallowequal';
-import omit from 'lodash.omit';
+import omit from 'just-omit';
 import { commonPropTypes, commonDefaultProps } from '../utils/commonProps';
 import { cubicOut } from '../utils/easings';
 import assertIsElement from '../utils/assertIsElement';

--- a/src/components/CSSGridItem.jsx
+++ b/src/components/CSSGridItem.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import shallowEqual from 'shallowequal';
-import omit from 'lodash.omit';
+import omit from 'just-omit';
 import { buildTransform, positionToProperties } from '../utils/transformHelpers';
 
 export default class extends Component {

--- a/src/components/SpringGrid.jsx
+++ b/src/components/SpringGrid.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { TransitionMotion, spring } from 'react-motion';
 import stripStyle from 'react-motion/lib/stripStyle';
 import shallowEqual from 'shallowequal';
-import omit from 'lodash.omit';
+import omit from 'just-omit';
 import { buildTransform, positionToProperties } from '../utils/transformHelpers';
 import { commonPropTypes, commonDefaultProps } from '../utils/commonProps';
 import assertIsElement from '../utils/assertIsElement';

--- a/src/higher-order-components/measureItems.jsx
+++ b/src/higher-order-components/measureItems.jsx
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
-import partition from 'lodash.partition';
-import debounce from 'lodash.debounce';
+import debounce from 'debounce';
 import { commonDefaultProps } from '../utils/commonProps';
 
 const imagesLoaded = typeof window !== 'undefined' ? require('imagesloaded') : null;
@@ -93,9 +92,9 @@ export default (Grid, { measureImages, background } = {}) => class extends Compo
   render() {
     const { component } = this.props;
 
-    const [newElements, existingElements] = partition(
-      React.Children.toArray(this.props.children),
-      element => !this.state.rects[element.key]);
+    const children = React.Children.toArray(this.props.children);
+    const newElements = children.filter(element => !this.state.rects[element.key]);
+    const existingElements = children.filter(element => this.state.rects[element.key]);
 
     const elementsToMeasure = newElements.map(element =>
       React.cloneElement(element, {


### PR DESCRIPTION
This changes reduce my bundle size from 700kB to 691kB. 9kB is a small changes, but if I use 10 packages with 9kB overhead... it's 90kb useless code.