### PR TITLE
Breakout PropTypes to its own package

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "lodash.debounce": "^4.0.8",
     "lodash.omit": "^4.5.0",
     "lodash.partition": "^4.6.0",
+    "prop-types": "^15.5.10",
     "react-addons-transition-group": "^15.4.2",
     "react-motion": "^0.4.7",
     "shallowequal": "^0.2.2"

--- a/src/components/CSSGrid.jsx
+++ b/src/components/CSSGrid.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import ReactTransitionGroup from 'react-addons-transition-group';
 import shallowEqual from 'shallowequal';
 import omit from 'lodash.omit';
@@ -11,8 +12,8 @@ export default class extends Component {
 
   static propTypes = {
     ...commonPropTypes,
-    duration: React.PropTypes.number.isRequired,
-    easing: React.PropTypes.string
+    duration: PropTypes.number.isRequired,
+    easing: PropTypes.string
   };
 
   static defaultProps = {

--- a/src/components/SpringGrid.jsx
+++ b/src/components/SpringGrid.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { TransitionMotion, spring } from 'react-motion';
 import stripStyle from 'react-motion/lib/stripStyle';
 import shallowEqual from 'shallowequal';
@@ -11,10 +12,10 @@ export default class extends Component {
 
   static propTypes = {
     ...commonPropTypes,
-    springConfig: React.PropTypes.shape({
-      stiffness: React.PropTypes.number,
-      damping: React.PropTypes.number,
-      precision: React.PropTypes.number
+    springConfig: PropTypes.shape({
+      stiffness: PropTypes.number,
+      damping: PropTypes.number,
+      precision: PropTypes.number
     })
   };
 

--- a/src/layouts/simple.js
+++ b/src/layouts/simple.js
@@ -1,4 +1,3 @@
-
 export default function(items, props) {
   const { columnWidth, itemHeight = 150, columns,
     gutterWidth, gutterHeight } = props;

--- a/src/layouts/simple.js
+++ b/src/layouts/simple.js
@@ -1,3 +1,4 @@
+
 export default function(items, props) {
   const { columnWidth, itemHeight = 150, columns,
     gutterWidth, gutterHeight } = props;

--- a/src/utils/commonProps.js
+++ b/src/utils/commonProps.js
@@ -1,20 +1,21 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import simpleLayout from '../layouts/simple';
 import * as simpleEnterExit from '../enter-exit-styles/simple';
 
 export const commonPropTypes = {
-  columns: React.PropTypes.number.isRequired,
-  columnWidth: React.PropTypes.number.isRequired,
-  gutterWidth: React.PropTypes.number,
-  gutterHeight: React.PropTypes.number,
-  component: React.PropTypes.string,
-  layout: React.PropTypes.func,
-  enter: React.PropTypes.func,
-  entered: React.PropTypes.func,
-  exit: React.PropTypes.func,
-  perspective: React.PropTypes.number,
-  lengthUnit: React.PropTypes.string,
-  angleUnit: React.PropTypes.string
+  columns: PropTypes.number.isRequired,
+  columnWidth: PropTypes.number.isRequired,
+  gutterWidth: PropTypes.number,
+  gutterHeight: PropTypes.number,
+  component: PropTypes.string,
+  layout: PropTypes.func,
+  enter: PropTypes.func,
+  entered: PropTypes.func,
+  exit: PropTypes.func,
+  perspective: PropTypes.number,
+  lengthUnit: PropTypes.string,
+  angleUnit: PropTypes.string
 };
 
 export const commonDefaultProps = {


### PR DESCRIPTION
The PropTypes package was broken out of React into its own NPM package "prop-types".   React 15.5 will console.error if you still use proptypes as part of the react package. 